### PR TITLE
fix: xcode `Multiple commands produce......`

### DIFF
--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -44,9 +44,9 @@ CFLAGS_x86_64_apple_darwin="-target x86_64-apple-darwin" \
 $cargo_build --target x86_64-apple-darwin --locked --release
 
 # copies the generated header into the build folder structure for local XCFramework usage
-mkdir -p "${BUILD_FOLDER}/includes"
-cp "${SWIFT_FOLDER}/loroFFI.h" "${BUILD_FOLDER}/includes"
-cp "${SWIFT_FOLDER}/loroFFI.modulemap" "${BUILD_FOLDER}/includes/module.modulemap"
+mkdir -p "${BUILD_FOLDER}/includes/loroFFI"
+cp "${SWIFT_FOLDER}/loroFFI.h" "${BUILD_FOLDER}/includes/loroFFI"
+cp "${SWIFT_FOLDER}/loroFFI.modulemap" "${BUILD_FOLDER}/includes/loroFFI/module.modulemap"
 cp -f "${SWIFT_FOLDER}/loro.swift" "${THIS_SCRIPT_DIR}/../Sources/Loro/LoroFFI.swift"
 
 echo "▸ Lipo (merge) x86 and arm macOS static libraries into a fat static binary"

--- a/scripts/build_swift_ffi.sh
+++ b/scripts/build_swift_ffi.sh
@@ -98,9 +98,9 @@ $cargo_build --target wasm32-wasi --locked --release
 # cp "${SWIFT_FOLDER}/automergeFFI.modulemap" "${SWIFT_FOLDER}/../Sources/_CAutomergeUniffi/include/module.modulemap"
 
 # copies the generated header into the build folder structure for local XCFramework usage
-mkdir -p "${BUILD_FOLDER}/includes"
-cp "${SWIFT_FOLDER}/loroFFI.h" "${BUILD_FOLDER}/includes"
-cp "${SWIFT_FOLDER}/loroFFI.modulemap" "${BUILD_FOLDER}/includes/module.modulemap"
+mkdir -p "${BUILD_FOLDER}/includes/loroFFI"
+cp "${SWIFT_FOLDER}/loroFFI.h" "${BUILD_FOLDER}/includes/loroFFI"
+cp "${SWIFT_FOLDER}/loroFFI.modulemap" "${BUILD_FOLDER}/includes/loroFFI/module.modulemap"
 
 echo "▸ Lipo (merge) x86 and arm simulator static libraries into a fat static binary"
 mkdir -p "${BUILD_FOLDER}/ios-simulator/release"


### PR DESCRIPTION
The error will be thrown when including both `automerge-swift` and `loro-swift`. The relevant conversation can be found [here](https://discord.com/channels/1069799218614640721/1268347050777510030/1271103704476553286). 

Thanks to @jessegrosjean!