### PR TITLE
refactor: upgrade to uniffi v0.29

### DIFF
--- a/loro-rs/Cargo.lock
+++ b/loro-rs/Cargo.lock
@@ -98,47 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ccd462b64c3c72f1be8305905a85d85403d768e8690c9b8bd3b9009a5761679"
 
 [[package]]
-name = "askama"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
-dependencies = [
- "askama_derive",
- "askama_escape",
-]
-
-[[package]]
-name = "askama_derive"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
-dependencies = [
- "askama_parser",
- "basic-toml",
- "mime",
- "mime_guess",
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
-name = "askama_parser"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,15 +117,6 @@ name = "basic-toml"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
@@ -619,8 +569,8 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "loro"
-version = "1.2.7"
-source = "git+https://github.com/loro-dev/loro.git?tag=loro-ffi%401.3.0#2df24725df3e9ed51f1dd2501730cc3785b46d4b"
+version = "1.3.2"
+source = "git+https://github.com/loro-dev/loro.git?branch=feat-upgrade-uniffi-029#af73b787639fa61669479f8527001422f8ba8499"
 dependencies = [
  "enum-as-inner 0.6.1",
  "fxhash",
@@ -634,8 +584,8 @@ dependencies = [
 
 [[package]]
 name = "loro-common"
-version = "1.2.7"
-source = "git+https://github.com/loro-dev/loro.git?tag=loro-ffi%401.3.0#2df24725df3e9ed51f1dd2501730cc3785b46d4b"
+version = "1.3.1"
+source = "git+https://github.com/loro-dev/loro.git?branch=feat-upgrade-uniffi-029#af73b787639fa61669479f8527001422f8ba8499"
 dependencies = [
  "arbitrary",
  "enum-as-inner 0.6.1",
@@ -651,8 +601,8 @@ dependencies = [
 
 [[package]]
 name = "loro-delta"
-version = "1.2.7"
-source = "git+https://github.com/loro-dev/loro.git?tag=loro-ffi%401.3.0#2df24725df3e9ed51f1dd2501730cc3785b46d4b"
+version = "1.3.1"
+source = "git+https://github.com/loro-dev/loro.git?branch=feat-upgrade-uniffi-029#af73b787639fa61669479f8527001422f8ba8499"
 dependencies = [
  "arrayvec",
  "enum-as-inner 0.5.1",
@@ -662,18 +612,17 @@ dependencies = [
 
 [[package]]
 name = "loro-ffi"
-version = "1.1.3"
-source = "git+https://github.com/loro-dev/loro.git?tag=loro-ffi%401.3.0#2df24725df3e9ed51f1dd2501730cc3785b46d4b"
+version = "1.3.2"
+source = "git+https://github.com/loro-dev/loro.git?branch=feat-upgrade-uniffi-029#af73b787639fa61669479f8527001422f8ba8499"
 dependencies = [
  "loro",
- "loro-internal",
  "serde_json",
 ]
 
 [[package]]
 name = "loro-internal"
-version = "1.2.7"
-source = "git+https://github.com/loro-dev/loro.git?tag=loro-ffi%401.3.0#2df24725df3e9ed51f1dd2501730cc3785b46d4b"
+version = "1.3.2"
+source = "git+https://github.com/loro-dev/loro.git?branch=feat-upgrade-uniffi-029#af73b787639fa61669479f8527001422f8ba8499"
 dependencies = [
  "append-only-bytes",
  "arref",
@@ -712,8 +661,8 @@ dependencies = [
 
 [[package]]
 name = "loro-kv-store"
-version = "1.2.7"
-source = "git+https://github.com/loro-dev/loro.git?tag=loro-ffi%401.3.0#2df24725df3e9ed51f1dd2501730cc3785b46d4b"
+version = "1.3.1"
+source = "git+https://github.com/loro-dev/loro.git?branch=feat-upgrade-uniffi-029#af73b787639fa61669479f8527001422f8ba8499"
 dependencies = [
  "bytes",
  "ensure-cov",
@@ -729,7 +678,7 @@ dependencies = [
 [[package]]
 name = "loro-rle"
 version = "1.2.7"
-source = "git+https://github.com/loro-dev/loro.git?tag=loro-ffi%401.3.0#2df24725df3e9ed51f1dd2501730cc3785b46d4b"
+source = "git+https://github.com/loro-dev/loro.git?branch=feat-upgrade-uniffi-029#af73b787639fa61669479f8527001422f8ba8499"
 dependencies = [
  "append-only-bytes",
  "num",
@@ -753,7 +702,7 @@ checksum = "3f3d053a135388e6b1df14e8af1212af5064746e9b87a06a345a7a779ee9695a"
 [[package]]
 name = "loro_fractional_index"
 version = "1.2.7"
-source = "git+https://github.com/loro-dev/loro.git?tag=loro-ffi%401.3.0#2df24725df3e9ed51f1dd2501730cc3785b46d4b"
+source = "git+https://github.com/loro-dev/loro.git?branch=feat-upgrade-uniffi-029#af73b787639fa61669479f8527001422f8ba8499"
 dependencies = [
  "once_cell",
  "rand",
@@ -1050,6 +999,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rinja"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc4940d00595430b3d7d5a01f6222b5e5b51395d1120bdb28d854bb8abb17a5"
+dependencies = [
+ "itoa",
+ "rinja_derive",
+]
+
+[[package]]
+name = "rinja_derive"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d9ed0146aef6e2825f1b1515f074510549efba38d71f4554eec32eb36ba18b"
+dependencies = [
+ "basic-toml",
+ "memchr",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rinja_parser",
+ "rustc-hash",
+ "serde",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "rinja_parser"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f9a866e2e00a7a1fb27e46e9e324a6f7c0e7edc4543cae1d38f4e4a100c610"
+dependencies = [
+ "memchr",
+ "nom",
+ "serde",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,9 +1332,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "uniffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
+checksum = "ba62a57e90f9baed5ad02a71a0870180fa1cc35499093b2d21be2edfb68ec0f7"
 dependencies = [
  "anyhow",
  "camino",
@@ -1354,12 +1348,11 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cade167af943e189a55020eda2c314681e223f1e42aca7c4e52614c2b627698f"
+checksum = "2242f35214f1e0e3b47c495d340c69f649f9a9ece3a943a29e275686cc884533"
 dependencies = [
  "anyhow",
- "askama",
  "camino",
  "cargo_metadata",
  "fs-err",
@@ -1368,6 +1361,7 @@ dependencies = [
  "heck 0.5.0",
  "once_cell",
  "paste",
+ "rinja",
  "serde",
  "textwrap",
  "toml",
@@ -1377,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7cf32576e08104b7dc2a6a5d815f37616e66c6866c2a639fe16e6d2286b75b"
+checksum = "c887a6c9a2857d8dc2ab0c8d578e8aa4978145b4fd65ed44296341e89aebc3cc"
 dependencies = [
  "anyhow",
  "camino",
@@ -1387,36 +1381,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_checksum_derive"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
-dependencies = [
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
 name = "uniffi_core"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
+checksum = "cad9fbdeb7ae4daf8d0f7704a3b638c37018eb16bb701e30fa17a2dd3e2d39c1"
 dependencies = [
  "anyhow",
  "bytes",
- "log",
  "once_cell",
  "paste",
  "static_assertions",
 ]
 
 [[package]]
-name = "uniffi_macros"
-version = "0.28.3"
+name = "uniffi_internal_macros"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
+checksum = "22a9dba1d78b9ce429439891089c223478043d52a1c3176a0fcea2b5573a7fcf"
 dependencies = [
- "bincode",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78dd5f8eefba5898b901086f5e7916da67b9a5286a01cc44e910cd75fa37c630"
+dependencies = [
  "camino",
  "fs-err",
  "once_cell",
@@ -1430,39 +1422,24 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a74ed96c26882dac1ca9b93ca23c827e284bacbd7ec23c6f0b0372f747d59e4"
+checksum = "9d5965b1d4ffacef1eaa72fef9c00d2491641e87ad910f6c5859b9c503ddb16a"
 dependencies = [
  "anyhow",
- "bytes",
  "siphasher",
- "uniffi_checksum_derive",
-]
-
-[[package]]
-name = "uniffi_testing"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6f984f0781f892cc864a62c3a5c60361b1ccbd68e538e6c9fbced5d82268ac"
-dependencies = [
- "anyhow",
- "camino",
- "cargo_metadata",
- "fs-err",
- "once_cell",
+ "uniffi_internal_macros",
 ]
 
 [[package]]
 name = "uniffi_udl"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
+checksum = "279b82bac9a382c796a0d210bb8354a0b813499b28aa1de046c85d78ca389805"
 dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta",
- "uniffi_testing",
  "weedle2",
 ]
 

--- a/loro-rs/Cargo.toml
+++ b/loro-rs/Cargo.toml
@@ -14,12 +14,12 @@ path = "src/uniffi-bindgen.rs"
 
 
 [dependencies]
-loro-ffi = { git = "https://github.com/loro-dev/loro.git", tag = "loro-ffi@1.3.0" }
+loro-ffi = { git = "https://github.com/loro-dev/loro.git", branch = "feat-upgrade-uniffi-029" }
 # loro-ffi = { path = "../../loro/crates/loro-ffi" }
-uniffi = { version = "0.28.3" }
+uniffi = { version = "0.29.0" }
 
 [build-dependencies]
-uniffi = { version = "0.28.3", features = ["build"] }
+uniffi = { version = "0.29.0", features = ["build"] }
 
 [features]
 cli = ["uniffi/cli"]

--- a/loro-rs/src/loro.udl
+++ b/loro-rs/src/loro.udl
@@ -5,23 +5,6 @@ namespace loro{
 };
 
 // ============= Traits =============
-
-[Trait]
-interface ValueOrContainer{
-    boolean is_value();
-    boolean is_container();
-    ContainerType? container_type();
-    LoroValue? as_value();
-    ContainerID? as_container();
-    LoroText? as_loro_text();
-    LoroList? as_loro_list();
-    LoroMap? as_loro_map();
-    LoroTree? as_loro_tree();
-    LoroCounter? as_loro_counter();
-    LoroMovableList? as_loro_movable_list();
-    LoroUnknown? as_loro_unknown();
-};
-
 [Trait, WithForeign]
 interface LoroValueLike{
     LoroValue as_loro_value();
@@ -44,7 +27,7 @@ interface LocalUpdateCallback{
 
 [Trait, WithForeign]
 interface Unsubscriber{
-    void on_unsubscribe();
+   void on_unsubscribe();
 };
 
 [Trait, WithForeign]
@@ -69,7 +52,12 @@ interface ChangeAncestorsTraveler{
 };
 
 // ============= LORO DOC =============
-
+/// `LoroDoc` is the entry for the whole document.
+/// When it's dropped, all the associated [`Handler`]s will be invalidated.
+///
+/// **Important:** Loro is a pure library and does not handle network protocols.
+/// It is the responsibility of the user to manage the storage, loading, and synchronization
+/// of the bytes exported by Loro in a manner suitable for their specific environment.
 interface LoroDoc{
     /// Create a new `LoroDoc` instance.
     constructor();
@@ -253,14 +241,6 @@ interface LoroDoc{
     /// Export the current state with json-string format of the document.
     string export_json_updates([ByRef]VersionVector start_vv, [ByRef]VersionVector end_vv);
 
-    /// Export all the ops not included in the given `VersionVector`
-    [Throws=LoroEncodeError]
-    bytes export_updates([ByRef] VersionVector vv);
-
-    /// Export the current state and history of the document.
-    [Throws=LoroEncodeError]
-    bytes export_snapshot();
-
     /// Convert `Frontiers` into `VersionVector`
     VersionVector? frontiers_to_vv([ByRef] Frontiers frontiers);
 
@@ -419,20 +399,9 @@ interface LoroDoc{
     /// The parsed ops will be dropped
     void compact_change_store();
 
-    // /// Export the document in the given mode.
-    // bytes export(ExportMode mode);
-
+    /// Export the document in the given mode.
     [Throws=LoroEncodeError]
-    bytes export_updates_in_range([ByRef]sequence<IdSpan> spans);
-
-    [Throws=LoroEncodeError]
-    bytes export_shallow_snapshot([ByRef]Frontiers frontiers);
-
-    [Throws=LoroEncodeError]
-    bytes export_snapshot_at([ByRef]Frontiers frontiers);
-
-    [Throws=LoroEncodeError]
-    bytes export_state_only(Frontiers? frontiers);
+    bytes export(ExportMode mode);
 
     // /// Analyze the container info of the doc
     // ///
@@ -558,6 +527,9 @@ interface LoroText{
     /// The edits on a detached container will not be persisted.
     /// To attach the container to the document, please insert it into an attached container.
     boolean is_attached();
+
+    /// If a detached container is attached, this method will return its corresponding attached handler.
+    LoroText? get_attached();
 
     /// Get the [ContainerID]  of the text container.
     ContainerID id();
@@ -687,6 +659,9 @@ interface LoroText{
 
     /// Get the editor of the text at the given position.
     u64? get_editor_at_unicode_pos(u32 pos);
+
+    /// Get the LoroDoc from this container
+    LoroDoc? doc();
 };
 
 interface LoroList{
@@ -701,6 +676,9 @@ interface LoroList{
     /// The edits on a detached container will not be persisted.
     /// To attach the container to the document, please insert it into an attached container.
     boolean is_attached();
+
+    /// If a detached container is attached, this method will return its corresponding attached handler.
+    LoroList? get_attached();
 
     /// Insert a value at the given position.
     [Throws=LoroError]
@@ -771,6 +749,9 @@ interface LoroList{
 
     /// Whether the container is deleted.
     boolean is_deleted();
+
+    /// Get the LoroDoc from this container
+    LoroDoc? doc();
 };
 
 interface LoroMap{
@@ -783,11 +764,17 @@ interface LoroMap{
     /// Whether the container is attached to a document.
     boolean is_attached();
 
+    /// If a detached container is attached, this method will return its corresponding attached handler.
+    LoroMap? get_attached();
+
     /// Delete a key-value pair from the map.
     [Throws=LoroError]
     void delete([ByRef] string key);
 
     /// Insert a key-value pair into the map.
+    ///
+    /// > **Note**: When calling `map.set(key, value)` on a LoroMap, if `map.get(key)` already returns `value`,
+    /// > the operation will be a no-op (no operation recorded) to avoid unnecessary updates.
     [Throws=LoroError]
     void insert([ByRef] string key, LoroValueLike v);
 
@@ -842,6 +829,9 @@ interface LoroMap{
 
     /// Get the values of the map.
     sequence<ValueOrContainer> values();
+
+    /// Get the LoroDoc from this container
+    LoroDoc? doc();
 };
 
 interface LoroTree{
@@ -856,6 +846,9 @@ interface LoroTree{
     /// The edits on a detached container will not be persisted.
     /// To attach the container to the document, please insert it into an attached container.
     boolean is_attached();
+
+    /// If a detached container is attached, this method will return its corresponding attached handler.
+    LoroTree? get_attached();
 
     /// Create a new tree node and return the [`TreeID`].
     ///
@@ -971,6 +964,9 @@ interface LoroTree{
 
     /// Whether the container is deleted.
     boolean is_deleted();
+
+    /// Get the LoroDoc from this container
+    LoroDoc? doc();
 };
 
 interface LoroMovableList{
@@ -985,6 +981,9 @@ interface LoroMovableList{
     /// The edits on a detached container will not be persisted.
     /// To attach the container to the document, please insert it into an attached container.
     boolean is_attached();
+
+    /// If a detached container is attached, this method will return its corresponding attached handler.
+    LoroMovableList? get_attached();
 
     /// Get the container id.
     ContainerID id();
@@ -1101,6 +1100,9 @@ interface LoroMovableList{
 
     /// Get the last editor of the list item at the given position.
     u64? get_last_editor_at(u32 pos);
+
+    /// Get the LoroDoc from this container
+    LoroDoc? doc();
 };
 
 interface LoroCounter{
@@ -1109,6 +1111,15 @@ interface LoroCounter{
 
     /// Return container id of the Counter.
     ContainerID id();
+
+    /// Whether the container is attached to a document
+    ///
+    /// The edits on a detached container will not be persisted.
+    /// To attach the container to the document, please insert it into an attached container.
+    boolean is_attached();
+
+    /// If a detached container is attached, this method will return its corresponding attached handler.
+    LoroCounter? get_attached();
 
     /// Increment the counter by the given value.
     [Throws=LoroError]
@@ -1123,6 +1134,9 @@ interface LoroCounter{
 
     /// Whether the container is deleted.
     boolean is_deleted();
+
+    /// Get the LoroDoc from this container
+    LoroDoc? doc();
 };
 
 interface LoroUnknown{
@@ -1130,17 +1144,33 @@ interface LoroUnknown{
     ContainerID id();
 };
 
+[Enum]
+interface Container{
+    List(LoroList container);
+    Map(LoroMap container);
+    Text(LoroText container);
+    Tree(LoroTree container);
+    MovableList(LoroMovableList container);
+    Counter(LoroCounter container);
+    Unknown(LoroUnknown container);
+};
+
+[Enum]
+interface ValueOrContainer{
+    Value(LoroValue value);
+    Container(Container container);
+};
+
 // ============= TYPES =============
 
-// TODO: https://github.com/mozilla/uniffi-rs/issues/1372
-// [Enum]
-// interface ExportMode{
-//     Snapshot();
-//     Updates(VersionVector from);
-//     UpdatesInRange(sequence<IdSpan> spans);
-//     GcSnapshot(Frontiers frontiers);
-//     StateOnly(Frontiers? frontiers);
-// };
+[Enum]
+interface ExportMode{
+    Snapshot();
+    Updates(VersionVector from);
+    UpdatesInRange(sequence<IdSpan> spans);
+    ShallowSnapshot(Frontiers frontiers);
+    StateOnly(Frontiers? frontiers);
+};
 
 dictionary ChangeMeta{
     /// Lamport timestamp of the Change
@@ -1189,7 +1219,6 @@ enum Ordering{
 
 
 // ============= CONFIG =============
-
 interface Configure{
     Configure fork();
     boolean record_timestamp();
@@ -1199,6 +1228,7 @@ interface Configure{
     StyleConfigMap text_style_config();
 };
 
+
 interface StyleConfigMap{
     constructor();
     [Name=default_rich_text_config]
@@ -1207,9 +1237,11 @@ interface StyleConfigMap{
     StyleConfig? get([ByRef] string key);
 };
 
+
 dictionary StyleConfig{
     ExpandType expand;
 };
+
 
 enum ExpandType{
     "Before",
@@ -1217,6 +1249,7 @@ enum ExpandType{
     "Both",
     "None",
 };
+
 
 dictionary CommitOptions{
     string? origin;
@@ -1227,26 +1260,29 @@ dictionary CommitOptions{
 
 // ============= CURSOR =============
 
-
 enum Side{
     "Left",
     "Middle",
     "Right",
 };
 
+
 interface Cursor{
     constructor(ID? id, ContainerID container, Side side, u32 origin_pos);
 };
+
 
 dictionary PosQueryResult{
     Cursor? update;
     AbsolutePosition current;
 };
 
+
 dictionary AbsolutePosition{
     u32 pos;
     Side side;
 };
+
 
 interface Awareness{
     constructor(u64 peer, i64 timeout);
@@ -1260,10 +1296,12 @@ interface Awareness{
     u64 peer();
 };
 
+
 dictionary AwarenessPeerUpdate{
     sequence<u64> updated;
     sequence<u64> added;
 };
+
 
 dictionary PeerInfo{
     LoroValue state;
@@ -1272,6 +1310,7 @@ dictionary PeerInfo{
 };
 
 // ============= VERSIONS =============
+
 interface VersionVector{
     constructor();
     void set_last(ID id);
@@ -1292,6 +1331,7 @@ interface VersionVector{
     boolean eq([ByRef]VersionVector other);
 };
 
+
 interface Frontiers{
     constructor();
     [Name=from_id]
@@ -1303,6 +1343,7 @@ interface Frontiers{
     constructor([ByRef]bytes bytes);
     boolean eq([ByRef]Frontiers other);
 };
+
 
 dictionary VersionVectorDiff{
     /// need to add these spans to move from right to left
@@ -1319,15 +1360,15 @@ interface UndoManager{
 
     /// Undo the last change made by the peer.
     [Throws=LoroError]
-    boolean undo([ByRef] LoroDoc doc);
+    boolean undo();
 
     /// Redo the last change made by the peer.
     [Throws=LoroError]
-    boolean redo([ByRef] LoroDoc doc);
+    boolean redo();
 
     /// Record a new checkpoint.
     [Throws=LoroError]
-    void record_new_checkpoint([ByRef] LoroDoc doc);
+    void record_new_checkpoint();
 
     /// Whether the undo manager can undo.
     boolean can_undo();


### PR DESCRIPTION
Here is an attempt using `uniffi-rs` v0.29, in which they support `Allow UDL to define Enums with objects` so that we can
```
[Enum]
interface Container{
    List(LoroList container);
    Map(LoroMap container);
    Text(LoroText container);
    Tree(LoroTree container);
    MovableList(LoroMovableList container);
    Counter(LoroCounter container);
    Unknown(LoroUnknown container);
};

[Enum]
interface ValueOrContainer{
    Value(LoroValue value);
    Container(Container container);
};
```

However, the definition of remote type is strengthened at the same time. In the current architecture, all types in `loro-ffi` are remote types. `uniffi-rs` do not yet support remote definitions of traits