### PR TITLE
feat: Upgrade Swift binding to 1.13.1

### DIFF
--- a/Sources/Loro/LoroFFI.swift
+++ b/Sources/Loro/LoroFFI.swift
@@ -4262,6 +4262,48 @@ public protocol LoroDocProtocol: AnyObject, Sendable {
     func travelChangeAncestors(ids: [Id], f: ChangeAncestorsTraveler) throws 
     
     /**
+     * Try to get a [LoroCounter] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+    func tryGetCounter(id: ContainerIdLike)  -> LoroCounter?
+    
+    /**
+     * Try to get a [LoroList] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+    func tryGetList(id: ContainerIdLike)  -> LoroList?
+    
+    /**
+     * Try to get a [LoroMap] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+    func tryGetMap(id: ContainerIdLike)  -> LoroMap?
+    
+    /**
+     * Try to get a [LoroMovableList] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+    func tryGetMovableList(id: ContainerIdLike)  -> LoroMovableList?
+    
+    /**
+     * Try to get a [LoroText] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+    func tryGetText(id: ContainerIdLike)  -> LoroText?
+    
+    /**
+     * Try to get a [LoroTree] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+    func tryGetTree(id: ContainerIdLike)  -> LoroTree?
+    
+    /**
      * Convert `VersionVector` into `Frontiers`
      */
     func vvToFrontiers(vv: VersionVector)  -> Frontiers
@@ -5558,6 +5600,90 @@ open func travelChangeAncestors(ids: [Id], f: ChangeAncestorsTraveler)throws   {
 }
     
     /**
+     * Try to get a [LoroCounter] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+open func tryGetCounter(id: ContainerIdLike) -> LoroCounter?  {
+    return try!  FfiConverterOptionTypeLoroCounter.lift(try! rustCall() {
+    uniffi_loro_ffi_fn_method_lorodoc_try_get_counter(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeContainerIdLike_lower(id),$0
+    )
+})
+}
+    
+    /**
+     * Try to get a [LoroList] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+open func tryGetList(id: ContainerIdLike) -> LoroList?  {
+    return try!  FfiConverterOptionTypeLoroList.lift(try! rustCall() {
+    uniffi_loro_ffi_fn_method_lorodoc_try_get_list(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeContainerIdLike_lower(id),$0
+    )
+})
+}
+    
+    /**
+     * Try to get a [LoroMap] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+open func tryGetMap(id: ContainerIdLike) -> LoroMap?  {
+    return try!  FfiConverterOptionTypeLoroMap.lift(try! rustCall() {
+    uniffi_loro_ffi_fn_method_lorodoc_try_get_map(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeContainerIdLike_lower(id),$0
+    )
+})
+}
+    
+    /**
+     * Try to get a [LoroMovableList] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+open func tryGetMovableList(id: ContainerIdLike) -> LoroMovableList?  {
+    return try!  FfiConverterOptionTypeLoroMovableList.lift(try! rustCall() {
+    uniffi_loro_ffi_fn_method_lorodoc_try_get_movable_list(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeContainerIdLike_lower(id),$0
+    )
+})
+}
+    
+    /**
+     * Try to get a [LoroText] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+open func tryGetText(id: ContainerIdLike) -> LoroText?  {
+    return try!  FfiConverterOptionTypeLoroText.lift(try! rustCall() {
+    uniffi_loro_ffi_fn_method_lorodoc_try_get_text(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeContainerIdLike_lower(id),$0
+    )
+})
+}
+    
+    /**
+     * Try to get a [LoroTree] by container id.
+     *
+     * Returns null if the container does not exist.
+     */
+open func tryGetTree(id: ContainerIdLike) -> LoroTree?  {
+    return try!  FfiConverterOptionTypeLoroTree.lift(try! rustCall() {
+    uniffi_loro_ffi_fn_method_lorodoc_try_get_tree(
+            self.uniffiCloneHandle(),
+        FfiConverterTypeContainerIdLike_lower(id),$0
+    )
+})
+}
+    
+    /**
      * Convert `VersionVector` into `Frontiers`
      */
 open func vvToFrontiers(vv: VersionVector) -> Frontiers  {
@@ -6149,6 +6275,18 @@ public protocol LoroMapProtocol: AnyObject, Sendable {
      */
     func doc()  -> LoroDoc?
     
+    func ensureMergeableCounter(key: String) throws  -> LoroCounter
+    
+    func ensureMergeableList(key: String) throws  -> LoroList
+    
+    func ensureMergeableMap(key: String) throws  -> LoroMap
+    
+    func ensureMergeableMovableList(key: String) throws  -> LoroMovableList
+    
+    func ensureMergeableText(key: String) throws  -> LoroText
+    
+    func ensureMergeableTree(key: String) throws  -> LoroTree
+    
     /**
      * Get the value of the map with the given key.
      */
@@ -6355,6 +6493,60 @@ open func doc() -> LoroDoc?  {
     return try!  FfiConverterOptionTypeLoroDoc.lift(try! rustCall() {
     uniffi_loro_ffi_fn_method_loromap_doc(
             self.uniffiCloneHandle(),$0
+    )
+})
+}
+    
+open func ensureMergeableCounter(key: String)throws  -> LoroCounter  {
+    return try  FfiConverterTypeLoroCounter_lift(try rustCallWithError(FfiConverterTypeLoroError_lift) {
+    uniffi_loro_ffi_fn_method_loromap_ensure_mergeable_counter(
+            self.uniffiCloneHandle(),
+        FfiConverterString.lower(key),$0
+    )
+})
+}
+    
+open func ensureMergeableList(key: String)throws  -> LoroList  {
+    return try  FfiConverterTypeLoroList_lift(try rustCallWithError(FfiConverterTypeLoroError_lift) {
+    uniffi_loro_ffi_fn_method_loromap_ensure_mergeable_list(
+            self.uniffiCloneHandle(),
+        FfiConverterString.lower(key),$0
+    )
+})
+}
+    
+open func ensureMergeableMap(key: String)throws  -> LoroMap  {
+    return try  FfiConverterTypeLoroMap_lift(try rustCallWithError(FfiConverterTypeLoroError_lift) {
+    uniffi_loro_ffi_fn_method_loromap_ensure_mergeable_map(
+            self.uniffiCloneHandle(),
+        FfiConverterString.lower(key),$0
+    )
+})
+}
+    
+open func ensureMergeableMovableList(key: String)throws  -> LoroMovableList  {
+    return try  FfiConverterTypeLoroMovableList_lift(try rustCallWithError(FfiConverterTypeLoroError_lift) {
+    uniffi_loro_ffi_fn_method_loromap_ensure_mergeable_movable_list(
+            self.uniffiCloneHandle(),
+        FfiConverterString.lower(key),$0
+    )
+})
+}
+    
+open func ensureMergeableText(key: String)throws  -> LoroText  {
+    return try  FfiConverterTypeLoroText_lift(try rustCallWithError(FfiConverterTypeLoroError_lift) {
+    uniffi_loro_ffi_fn_method_loromap_ensure_mergeable_text(
+            self.uniffiCloneHandle(),
+        FfiConverterString.lower(key),$0
+    )
+})
+}
+    
+open func ensureMergeableTree(key: String)throws  -> LoroTree  {
+    return try  FfiConverterTypeLoroTree_lift(try rustCallWithError(FfiConverterTypeLoroError_lift) {
+    uniffi_loro_ffi_fn_method_loromap_ensure_mergeable_tree(
+            self.uniffiCloneHandle(),
+        FfiConverterString.lower(key),$0
     )
 })
 }
@@ -17850,6 +18042,24 @@ private let initializationResult: InitializationResult = {
     if (uniffi_loro_ffi_checksum_method_lorodoc_travel_change_ancestors() != 32967) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_loro_ffi_checksum_method_lorodoc_try_get_counter() != 9399) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_loro_ffi_checksum_method_lorodoc_try_get_list() != 6950) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_loro_ffi_checksum_method_lorodoc_try_get_map() != 3034) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_loro_ffi_checksum_method_lorodoc_try_get_movable_list() != 10796) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_loro_ffi_checksum_method_lorodoc_try_get_text() != 31311) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_loro_ffi_checksum_method_lorodoc_try_get_tree() != 13197) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_loro_ffi_checksum_method_lorodoc_vv_to_frontiers() != 18612) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -17935,6 +18145,24 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_loro_ffi_checksum_method_loromap_doc() != 18081) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_loro_ffi_checksum_method_loromap_ensure_mergeable_counter() != 45050) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_loro_ffi_checksum_method_loromap_ensure_mergeable_list() != 52705) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_loro_ffi_checksum_method_loromap_ensure_mergeable_map() != 9978) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_loro_ffi_checksum_method_loromap_ensure_mergeable_movable_list() != 54435) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_loro_ffi_checksum_method_loromap_ensure_mergeable_text() != 48183) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_loro_ffi_checksum_method_loromap_ensure_mergeable_tree() != 32019) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_loro_ffi_checksum_method_loromap_get() != 28557) {

--- a/Tests/LoroTests/LoroTests.swift
+++ b/Tests/LoroTests/LoroTests.swift
@@ -54,6 +54,42 @@ final class LoroTests: XCTestCase {
         XCTAssertEqual(map.get(key: "key")!.asValue()!, LoroValue.string(value:"value"))
     }
 
+    func testEnsureMergeableMap(){
+        let docA = LoroDoc()
+        try! docA.setPeerId(peer: 1)
+        let profileA = try! docA.getMap(id: "root").ensureMergeableMap(key: "profile")
+        try! profileA.insert(key: "name", v: "Ada")
+        docA.commit()
+
+        let docB = LoroDoc()
+        try! docB.setPeerId(peer: 2)
+        let profileB = try! docB.getMap(id: "root").ensureMergeableMap(key: "profile")
+        try! profileB.insert(key: "age", v: 37)
+        docB.commit()
+
+        let _ = try! docA.import(bytes: docB.export(mode: .snapshot))
+        let _ = try! docB.import(bytes: docA.export(mode: .snapshot))
+
+        let expected = LoroValue.map(value: [
+            "root": .map(value: [
+                "profile": .map(value: [
+                    "name": .string(value: "Ada"),
+                    "age": .i64(value: 37),
+                ])
+            ])
+        ])
+        XCTAssertEqual(docA.getDeepValue(), expected)
+        XCTAssertEqual(docB.getDeepValue(), expected)
+    }
+
+    func testEnsureMergeableRejectsOccupiedKey(){
+        let doc = LoroDoc()
+        let root = doc.getMap(id: "root")
+        try! root.insert(key: "profile", v: "occupied")
+
+        XCTAssertThrowsError(try root.ensureMergeableMap(key: "profile"))
+    }
+
     func testSync(){
         let doc = LoroDoc()
         try! doc.setPeerId(peer: 0)

--- a/loro-swift/Cargo.lock
+++ b/loro-swift/Cargo.lock
@@ -773,6 +773,8 @@ dependencies = [
 [[package]]
 name = "loro-ffi"
 version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128045da1884d235943b6e35595dc4fb3128b39af75ca93ea1d466b3a000f28a"
 dependencies = [
  "loro",
  "serde_json",

--- a/loro-swift/Cargo.lock
+++ b/loro-swift/Cargo.lock
@@ -726,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "loro"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63def75cde167dbc652d21bc6f56e2dc44ce90a5332eb900c42c51ad0e5ed46"
+checksum = "7bd1b63cd2f0cf66acbbb3191c41feaff03c94c3f6c6bb1e61d2ab3062c301c7"
 dependencies = [
  "enum-as-inner 0.6.1",
  "generic-btree",
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "loro-common"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b4ed29838b513f39424d17f1a4cbfa46b345db5d81e240ec3df26d810bb195"
+checksum = "b51042936156a1d537df8a38938ec8ed24b45de14530af933c1d02de39c9e056"
 dependencies = [
  "arbitrary",
  "enum-as-inner 0.6.1",
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "loro-delta"
-version = "1.9.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eafa788a72c1cbf0b7dc08a862cd7cc31b96d99c2ef749cdc94c2330f9494d3"
+checksum = "96f381e7fb5d4bf5605b4f4a9241f3adf61403ded978d757552004c8302cccbb"
 dependencies = [
  "arrayvec",
  "enum-as-inner 0.5.1",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "loro-ffi"
-version = "1.11.1"
+version = "1.13.1"
 dependencies = [
  "loro",
  "serde_json",
@@ -781,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "loro-internal"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4d9040942768f57efe9e4b532cd1400fe510e7627acc4c4ea2a1d74eececa9"
+checksum = "252a84196402ac55a7dd064af87a747a430fc176ec744d5bb99f4ed92e639fa8"
 dependencies = [
  "append-only-bytes",
  "arref",
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "loro-kv-store"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b4feac38d7422f53b935644647329fa50db4dfa26d9d40190ad7beb722cea73"
+checksum = "950cc8bcc64dcff536e949fbc56ccc3d0759646fa441c7f76b3cd7c3eafa2096"
 dependencies = [
  "bytes",
  "ensure-cov",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "loro-swift"
-version = "1.10.3"
+version = "1.13.1"
 dependencies = [
  "loro-ffi",
  "uniffi",
@@ -870,9 +870,9 @@ checksum = "3f3d053a135388e6b1df14e8af1212af5064746e9b87a06a345a7a779ee9695a"
 
 [[package]]
 name = "loro_fractional_index"
-version = "1.6.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c8ea186958094052b971fe7e322a934b034c3bf62f0458ccea04fcd687ba1"
+checksum = "aca7180674d0273ddf37049a5efcde4547fd5330d24abb7519bb9d9eb6780d5b"
 dependencies = [
  "once_cell",
  "rand",

--- a/loro-swift/Cargo.toml
+++ b/loro-swift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loro-swift"
-version = "1.12.0"
+version = "1.13.1"
 edition = "2021"
 
 [lib]
@@ -11,7 +11,7 @@ name = "uniffi-bindgen"
 path = "src/uniffi-bindgen.rs"
 
 [dependencies]
-loro-ffi = { version = "1.12.0" }
+loro-ffi = { version = "1.13.1" }
 uniffi = { version = "0.31.1" }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
- Upgrade the Swift Rust shim to `loro-ffi` 1.13.1.
- Use the published `loro-ffi` 1.13.1 crate in Cargo.lock.
- Regenerate `Sources/Loro/LoroFFI.swift` with `ensureMergeable*` APIs.
- Add Swift tests for mergeable map convergence and occupied-key errors.

## Validation
- `cargo check --manifest-path loro-swift/Cargo.toml`
- `sh scripts/build_macos.sh`
- `LOCAL_BUILD=1 swift test` (42 tests passed)
